### PR TITLE
start janus after the network interface is up

### DIFF
--- a/docs/janus-deployment.md
+++ b/docs/janus-deployment.md
@@ -277,7 +277,8 @@ Create a file `/etc/systemd/system/janus.service` with this content:
 [Unit]
 Description=Janus WebRTC Server
 Documentation=https://janus.conf.meetecho.com/
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
See https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/
that explains the difference between `network.target` and `network-online.target`