### PR TITLE
upgrade to latest janus 0.x

### DIFF
--- a/docs/janus-deployment.md
+++ b/docs/janus-deployment.md
@@ -19,7 +19,8 @@ It was the case for the janus upgrade from 0.9.x to 0.10.x (api_version 14 to 15
 You may look at the [PR #61](https://github.com/mozilla/janus-plugin-sfu/pull/61) for
 some pointers how to do that if you want to contribute the next needed upgrade.
 
-Please note that janus-gateway master since 2022-02-11 changed to include the multistream changes ([PR-2211 multistream](https://github.com/meetecho/janus-gateway/pull/2211) was merged). The janus-plugin-sfu Rust code is currently working with the [janus-gateway 0.x branch](https://github.com/meetecho/janus-gateway/tree/0.x)
+Please note that janus-gateway master since 2022-02-11 changed to include the multistream changes ([PR-2211 multistream](https://github.com/meetecho/janus-gateway/pull/2211) was merged, [see the post](https://www.meetecho.com/blog/multistream/)).
+The janus-plugin-sfu Rust code is currently working with the [janus-gateway 0.x branch](https://github.com/meetecho/janus-gateway/tree/0.x)
 
 There is an API change 15 to 16 in this commit https://github.com/meetecho/janus-gateway/commit/f9906da03e011d6ac457d49a3b5473c320b01e6e (release v0.11.6) that is not currently addressed in janus-plugin-rs and janus-plugin-sfu. You can use janus-gateway 0.x branch and revert this commit to come back to API 15, janus-plugin-sfu will work fine in this case.
 

--- a/docs/janus-deployment.md
+++ b/docs/janus-deployment.md
@@ -159,7 +159,7 @@ general: {
 }
 media: {
   rtp_port_range = "51610-65535"
-  slowlink_threshold = 4  # default to 0 (disabled) post v0.11.6, put it back to 4 if you want to have logs and events to know that a participant lost packets
+  slowlink_threshold = 4  # default to 0 (disabled) in v0.11.7, put it back to 4 if you want to have logs and events to know that a participant lost packets
 }
 nat: {
   nice_debug = false  # set it to true to have more logs

--- a/docs/janus-deployment.md
+++ b/docs/janus-deployment.md
@@ -18,11 +18,12 @@ Historical note: janus-gateway may change its API version and both [janus-plugin
 It was the case for the janus upgrade from 0.9.x to 0.10.x (api_version 14 to 15).
 You may look at the [PR #61](https://github.com/mozilla/janus-plugin-sfu/pull/61) for
 some pointers how to do that if you want to contribute the next needed upgrade.
+Another example is the update to api_version 16 (janus 0.11.6), see
+[janus-plugin-rs PR #31](https://github.com/mozilla/janus-plugin-rs/pull/31) and
+[networked-aframe/janus-plugin-sfu PR #1](https://github.com/networked-aframe/janus-plugin-sfu/pull/1)
 
 Please note that janus-gateway master since 2022-02-11 changed to include the multistream changes ([PR-2211 multistream](https://github.com/meetecho/janus-gateway/pull/2211) was merged, [see the post](https://www.meetecho.com/blog/multistream/)).
 The janus-plugin-sfu Rust code is currently working with the [janus-gateway 0.x branch](https://github.com/meetecho/janus-gateway/tree/0.x)
-
-There is an API change 15 to 16 in this commit https://github.com/meetecho/janus-gateway/commit/f9906da03e011d6ac457d49a3b5473c320b01e6e (release v0.11.6) that is not currently addressed in janus-plugin-rs and janus-plugin-sfu. You can use janus-gateway 0.x branch and revert this commit to come back to API 15, janus-plugin-sfu will work fine in this case.
 
 ## Automatic security upgrades with unattended-upgrades (optional)
 
@@ -127,12 +128,10 @@ git checkout 0.9.5.0 && \
 make && sudo make install
 
 cd /tmp
-# 2022-01-24 15:22 561b5d341a317abbbbcaa19eb4c89fb871dd1e4b (v0.11.7) from 0.x branch
-# with https://github.com/meetecho/janus-gateway/commit/f9906da03e011d6ac457d49a3b5473c320b01e6e reverted to come back to api 15
-# git clone https://github.com/meetecho/janus-gateway.git && \
-git clone -b 0.x-api15 https://github.com/vincentfretin/janus-gateway.git && \
+# 2022-02-11 10:26 8b9e96eb9e9db2f6a4b1507b02c79ffc7bcf0f0c (v0.11.8 from 0.x branch)
+git clone -b 0.x https://github.com/meetecho/janus-gateway.git && \
 cd janus-gateway && \
-git checkout 372ab47789c64ae8a13bd0f38237777c8edbdf0b && \
+git checkout 8b9e96eb9e9db2f6a4b1507b02c79ffc7bcf0f0c && \
 sh autogen.sh && \
 CFLAGS="${CFLAGS} -fno-omit-frame-pointer" ./configure --prefix=/usr \
 --disable-all-plugins --disable-all-handlers && \

--- a/docs/janus-deployment.md
+++ b/docs/janus-deployment.md
@@ -8,7 +8,7 @@ You can follow the build instructions below but you should use latest versions i
 This documentation won't necessary be updated.
 
 Look at the [README history of janus-gateway](https://github.com/meetecho/janus-gateway/commits/master/README.md) to see if the build instructions
-for some components changed, this happened several times. The build instructions below was up to date the 2022-01-22.
+for some components changed, this happened several times. The build instructions below was up to date the 2022-02-12.
 Look at the changes in master or releases in the different repositories of the components you need to build to see if you can update them.
 
 Follow at least the [janus-gateway](https://github.com/meetecho/janus-gateway) and the [janus-plugin-sfu](https://github.com/networked-aframe/janus-plugin-sfu) repositories and the [janus mailing-list](https://groups.google.com/g/meetecho-janus) for updates.

--- a/docs/janus-deployment.md
+++ b/docs/janus-deployment.md
@@ -11,7 +11,7 @@ Look at the [README history of janus-gateway](https://github.com/meetecho/janus-
 for some components changed, this happened several times. The build instructions below was up to date the 2022-01-22.
 Look at the changes in master or releases in the different repositories of the components you need to build to see if you can update them.
 
-Follow at least the [janus-gateway](https://github.com/meetecho/janus-gateway) and the [janus-plugin-sfu](https://github.com/mozilla/janus-plugin-sfu) repositories and the [janus mailing-list](https://groups.google.com/g/meetecho-janus) for updates.
+Follow at least the [janus-gateway](https://github.com/meetecho/janus-gateway) and the [janus-plugin-sfu](https://github.com/networked-aframe/janus-plugin-sfu) repositories and the [janus mailing-list](https://groups.google.com/g/meetecho-janus) for updates.
 
 Historical note: janus-gateway may change its API version and both [janus-plugin-rs](https://github.com/mozilla/janus-plugin-rs)
 (the C to Rust binding) and janus-plugin-sfu (Rust only) may need to be adapted.
@@ -138,7 +138,7 @@ CFLAGS="${CFLAGS} -fno-omit-frame-pointer" ./configure --prefix=/usr \
 make && sudo make install && sudo make configs
 
 cd /tmp
-git clone -b master https://github.com/mozilla/janus-plugin-sfu.git && cd janus-plugin-sfu && \
+git clone -b master https://github.com/networked-aframe/janus-plugin-sfu.git && cd janus-plugin-sfu && \
 cargo build --release && \
 sudo mkdir -p /usr/lib/janus/plugins && \
 sudo mkdir -p /usr/lib/janus/events && \

--- a/docs/janus-deployment.md
+++ b/docs/janus-deployment.md
@@ -126,12 +126,12 @@ git checkout 0.9.5.0 && \
 make && sudo make install
 
 cd /tmp
-# 2022-01-10 14:07 ee5807affd985537380d00c7d70ca7ddf31a3d30 (post v0.11.6) from 0.x branch
+# 2022-01-24 15:22 561b5d341a317abbbbcaa19eb4c89fb871dd1e4b (v0.11.7) from 0.x branch
 # with https://github.com/meetecho/janus-gateway/commit/f9906da03e011d6ac457d49a3b5473c320b01e6e reverted to come back to api 15
 # git clone https://github.com/meetecho/janus-gateway.git && \
 git clone -b 0.x-api15 https://github.com/vincentfretin/janus-gateway.git && \
 cd janus-gateway && \
-git checkout b4c025ffee49b12e51f849ecaf7904ba4bd3ecc6 && \
+git checkout 372ab47789c64ae8a13bd0f38237777c8edbdf0b && \
 sh autogen.sh && \
 CFLAGS="${CFLAGS} -fno-omit-frame-pointer" ./configure --prefix=/usr \
 --disable-all-plugins --disable-all-handlers && \

--- a/docs/janus-deployment.md
+++ b/docs/janus-deployment.md
@@ -8,7 +8,7 @@ You can follow the build instructions below but you should use latest versions i
 This documentation won't necessary be updated.
 
 Look at the [README history of janus-gateway](https://github.com/meetecho/janus-gateway/commits/master/README.md) to see if the build instructions
-for some components changed, this happened several times. The build instructions below was up to date the Mar 25, 2021.
+for some components changed, this happened several times. The build instructions below was up to date the 2022-01-22.
 Look at the changes in master or releases in the different repositories of the components you need to build to see if you can update them.
 
 Follow at least the [janus-gateway](https://github.com/meetecho/janus-gateway) and the [janus-plugin-sfu](https://github.com/mozilla/janus-plugin-sfu) repositories and the [janus mailing-list](https://groups.google.com/g/meetecho-janus) for updates.
@@ -18,6 +18,10 @@ Historical note: janus-gateway may change its API version and both [janus-plugin
 It was the case for the janus upgrade from 0.9.x to 0.10.x (api_version 14 to 15).
 You may look at the [PR #61](https://github.com/mozilla/janus-plugin-sfu/pull/61) for
 some pointers how to do that if you want to contribute the next needed upgrade.
+
+Please note that janus-gateway master since 2022-02-11 changed to include the multistream changes ([PR-2211 multistream](https://github.com/meetecho/janus-gateway/pull/2211) was merged). The janus-plugin-sfu Rust code is currently working with the [janus-gateway 0.x branch](https://github.com/meetecho/janus-gateway/tree/0.x)
+
+There is an API change 15 to 16 in this commit https://github.com/meetecho/janus-gateway/commit/f9906da03e011d6ac457d49a3b5473c320b01e6e (release v0.11.6) that is not currently addressed in janus-plugin-rs and janus-plugin-sfu. You can use janus-gateway 0.x branch and revert this commit to come back to API 15, janus-plugin-sfu will work fine in this case.
 
 ## Automatic security upgrades with unattended-upgrades (optional)
 
@@ -122,9 +126,12 @@ git checkout 0.9.5.0 && \
 make && sudo make install
 
 cd /tmp
-# 2021-04-06 12:36 d52e33259de3088ff964440fafd17ca58f8ba9bc (v0.11.1)
-git clone https://github.com/meetecho/janus-gateway.git && cd janus-gateway && \
-git checkout d52e33259de3088ff964440fafd17ca58f8ba9bc && \
+# 2022-01-10 14:07 ee5807affd985537380d00c7d70ca7ddf31a3d30 (post v0.11.6) from 0.x branch
+# with https://github.com/meetecho/janus-gateway/commit/f9906da03e011d6ac457d49a3b5473c320b01e6e reverted to come back to api 15
+# git clone https://github.com/meetecho/janus-gateway.git && \
+git clone -b 0.x-api15 https://github.com/vincentfretin/janus-gateway.git && \
+cd janus-gateway && \
+git checkout b4c025ffee49b12e51f849ecaf7904ba4bd3ecc6 && \
 sh autogen.sh && \
 CFLAGS="${CFLAGS} -fno-omit-frame-pointer" ./configure --prefix=/usr \
 --disable-all-plugins --disable-all-handlers && \
@@ -152,6 +159,7 @@ general: {
 }
 media: {
   rtp_port_range = "51610-65535"
+  slowlink_threshold = 4  # default to 0 (disabled) post v0.11.6, put it back to 4 if you want to have logs and events to know that a participant lost packets
 }
 nat: {
   nice_debug = false  # set it to true to have more logs


### PR DESCRIPTION
Upgrade janus to latest 0.11.7 version.
Compared to v0.11.1, changes that may interest us are related to faster parsing and writing sdp.

[v0.11.5] - 2021-10-18
- Fixed slow path on SDP parsing [PR-2776]
  https://github.com/meetecho/janus-gateway/pull/2776/commits/90147ba4c1c699be9746c456c800163706447069
  https://github.com/meetecho/janus-gateway/pull/2776/commits/f2ed527843164f0466370eead783c538505671ad

[v0.11.6] - 2021-12-13
- The API was incremented from 15 to 16 because of a new auth_is_signed function in the Plugin interface, that is used in the videoroom plugin.
https://github.com/meetecho/janus-gateway/commit/f9906da03e011d6ac457d49a3b5473c320b01e6e
This change will need a change in janus-plugin-rs and janus-plugin-sfu. For now, we can do a build without this commit.
- Grow buffer as needed when generating SDPs [PR-2797]
  https://github.com/meetecho/janus-gateway/commit/326b00c5b5184d6bafb4630669c49ef03be4f4ef

[v0.11.7] - 2022-01-24
- Disable slowlink events by default [PR-2803]
  https://github.com/meetecho/janus-gateway/pull/2803/commits/4e86131c3c3afd8c2b4e2827c1bef3de0575eadf
- Added faster strlcat variant that uses memccpy for writing SDPs [PR-2835]
  https://github.com/meetecho/janus-gateway/commit/fc9ece33364ccbd098c21df2812a4369b064f0de

I leave this in draft for now, mainly because this currently uses my fork. Changes in janus-plugin-rs and janus-plugin-sfu should be properly done instead. Also I'll test that on my server before merging.