### PR TITLE
Add loop_index configuration for janus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1297,6 +1297,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3347,6 +3357,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/fill-range": {
       "version": "4.0.0",
@@ -5731,6 +5748,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -10924,6 +10948,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -12674,6 +12708,13 @@
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -14550,6 +14591,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/src/index.js
+++ b/src/index.js
@@ -186,6 +186,10 @@ class JanusAdapter {
     this.onReconnectionError = reconnectionErrorListener;
   }
 
+  setCores(cores) {
+    this.cores = cores;
+  }
+
   connect() {
     debug(`connecting to ${this.serverUrl}`);
 
@@ -495,7 +499,7 @@ class JanusAdapter {
     var conn = new RTCPeerConnection(this.peerConnectionConfig || DEFAULT_PEER_CONNECTION_CONFIG);
 
     debug("pub waiting for sfu");
-    await handle.attach("janus.plugin.sfu");
+    await handle.attach("janus.plugin.sfu", this.cores && this.clientId? parseInt(this.clientId) % this.cores : undefined);
 
     this.associate(conn, handle);
 
@@ -637,7 +641,7 @@ class JanusAdapter {
     var conn = new RTCPeerConnection(this.peerConnectionConfig || DEFAULT_PEER_CONNECTION_CONFIG);
 
     debug(occupantId + ": sub waiting for sfu");
-    await handle.attach("janus.plugin.sfu");
+    await handle.attach("janus.plugin.sfu", this.cores ? parseInt(occupantId) % this.cores : undefined);
 
     this.associate(conn, handle);
 

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,7 @@ class JanusAdapter {
     this.onReconnectionError = reconnectionErrorListener;
   }
 
-  setLoops(loops) {
+  setEventLoops(loops) {
     this.loops = loops;
   }
 
@@ -499,7 +499,7 @@ class JanusAdapter {
     var conn = new RTCPeerConnection(this.peerConnectionConfig || DEFAULT_PEER_CONNECTION_CONFIG);
 
     debug("pub waiting for sfu");
-    await handle.attach("janus.plugin.sfu", this.loops && this.clientId? parseInt(this.clientId) % this.loops : undefined);
+    await handle.attach("janus.plugin.sfu", this.loops && this.clientId ? parseInt(this.clientId) % this.loops : undefined);
 
     this.associate(conn, handle);
 

--- a/src/index.js
+++ b/src/index.js
@@ -186,8 +186,8 @@ class JanusAdapter {
     this.onReconnectionError = reconnectionErrorListener;
   }
 
-  setCores(cores) {
-    this.cores = cores;
+  setLoops(loops) {
+    this.loops = loops;
   }
 
   connect() {
@@ -499,7 +499,7 @@ class JanusAdapter {
     var conn = new RTCPeerConnection(this.peerConnectionConfig || DEFAULT_PEER_CONNECTION_CONFIG);
 
     debug("pub waiting for sfu");
-    await handle.attach("janus.plugin.sfu", this.cores && this.clientId? parseInt(this.clientId) % this.cores : undefined);
+    await handle.attach("janus.plugin.sfu", this.loops && this.clientId? parseInt(this.clientId) % this.loops : undefined);
 
     this.associate(conn, handle);
 
@@ -641,7 +641,7 @@ class JanusAdapter {
     var conn = new RTCPeerConnection(this.peerConnectionConfig || DEFAULT_PEER_CONNECTION_CONFIG);
 
     debug(occupantId + ": sub waiting for sfu");
-    await handle.attach("janus.plugin.sfu", this.cores ? parseInt(occupantId) % this.cores : undefined);
+    await handle.attach("janus.plugin.sfu", this.loops ? parseInt(occupantId) % this.loops : undefined);
 
     this.associate(conn, handle);
 


### PR DESCRIPTION
This PR adds loops for the `loop_index` configuration to pass to the `attach` function of the minijanus (https://github.com/networked-aframe/minijanus.js/pull/2).


package-lock.json changes due to `npm ci` conflicts