### PR TITLE
Remove webpack-merge dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "np": "^8.0.4",
     "webpack": "^5.90.2",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.2",
-    "webpack-merge": "^5.10.0"
+    "webpack-dev-server": "^5.0.2"
   },
   "dependencies": {
     "debug": "^4.3.4",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,8 +1,7 @@
 const path = require("path");
-const { merge } = require("webpack-merge");
-const common = require("./webpack.common");
 
-module.exports = merge(common, {
+module.exports = {
+  extends: ['webpack.common.js'],
   mode: "development",
   devtool: "inline-source-map",
   devServer: {
@@ -20,4 +19,4 @@ module.exports = merge(common, {
       directory: path.resolve(__dirname, "examples"),
     },
   },
-});
+};

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,11 +1,10 @@
 const path = require("path");
-const { merge } = require("webpack-merge");
-const common = require("./webpack.common");
 
-module.exports = merge(common, {
+module.exports = {
+  extends: ['webpack.common.js'],
   mode: "production",
   output: {
     filename: "naf-janus-adapter.min.js"
   },
   devtool: "source-map"
-});
+};


### PR DESCRIPTION
webpack-merge is not needed in recent version of webpack. webpack has now a native feature to extend another config.