### PR TITLE
Don't subscribe to audio/video if occupant is a listener

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -337,10 +337,12 @@ class JanusAdapter {
 
     this.leftOccupants.delete(occupantId);
 
+    var subscriber;
     if (occupantId.endsWith("-l")) {
-      this.occupants[occupantId] = {};
+      subscriber = {};
+      this.occupants[occupantId] = subscriber;
     } else {
-      var subscriber = await this.createSubscriber(occupantId);
+      subscriber = await this.createSubscriber(occupantId);
 
       if (!subscriber) return;
 

--- a/src/index.js
+++ b/src/index.js
@@ -451,7 +451,7 @@ class JanusAdapter {
     var conn = new RTCPeerConnection(this.peerConnectionConfig || DEFAULT_PEER_CONNECTION_CONFIG);
 
     debug("pub waiting for sfu");
-    await handle.attach("janus.plugin.sfu", this.loops && this.clientId ? parseInt(this.clientId.replace("-l", "")) % this.loops : undefined);
+    await handle.attach("janus.plugin.sfu", this.loops && this.clientId ? parseInt(this.clientId) % this.loops : undefined);
 
     this.associate(conn, handle);
 

--- a/src/index.js
+++ b/src/index.js
@@ -589,7 +589,7 @@ class JanusAdapter {
     var conn = new RTCPeerConnection(this.peerConnectionConfig || DEFAULT_PEER_CONNECTION_CONFIG);
 
     debug(occupantId + ": sub waiting for sfu");
-    await handle.attach("janus.plugin.sfu", this.loops ? parseInt(occupantId.replace("-l", "")) % this.loops : undefined);
+    await handle.attach("janus.plugin.sfu", this.loops ? parseInt(occupantId) % this.loops : undefined);
 
     this.associate(conn, handle);
 

--- a/src/index.js
+++ b/src/index.js
@@ -337,13 +337,17 @@ class JanusAdapter {
 
     this.leftOccupants.delete(occupantId);
 
-    var subscriber = await this.createSubscriber(occupantId);
+    if (occupantId.endsWith("-l")) {
+      this.occupants[occupantId] = {};
+    } else {
+      var subscriber = await this.createSubscriber(occupantId);
 
-    if (!subscriber) return;
+      if (!subscriber) return;
 
-    this.occupants[occupantId] = subscriber;
+      this.occupants[occupantId] = subscriber;
 
-    this.setMediaStream(occupantId, subscriber.mediaStream);
+      this.setMediaStream(occupantId, subscriber.mediaStream);
+    }
 
     // Call the Networked AFrame callbacks for the new occupant.
     this.onOccupantConnected(occupantId);
@@ -363,7 +367,7 @@ class JanusAdapter {
 
     if (this.occupants[occupantId]) {
       // Close the subscriber peer connection. Which also detaches the plugin handle.
-      this.occupants[occupantId].conn.close();
+      this.occupants[occupantId].conn?.close();
       delete this.occupants[occupantId];
     }
 
@@ -445,7 +449,7 @@ class JanusAdapter {
     var conn = new RTCPeerConnection(this.peerConnectionConfig || DEFAULT_PEER_CONNECTION_CONFIG);
 
     debug("pub waiting for sfu");
-    await handle.attach("janus.plugin.sfu", this.loops && this.clientId ? parseInt(this.clientId) % this.loops : undefined);
+    await handle.attach("janus.plugin.sfu", this.loops && this.clientId ? parseInt(this.clientId.replace("-l", "")) % this.loops : undefined);
 
     this.associate(conn, handle);
 
@@ -585,7 +589,7 @@ class JanusAdapter {
     var conn = new RTCPeerConnection(this.peerConnectionConfig || DEFAULT_PEER_CONNECTION_CONFIG);
 
     debug(occupantId + ": sub waiting for sfu");
-    await handle.attach("janus.plugin.sfu", this.loops ? parseInt(occupantId) % this.loops : undefined);
+    await handle.attach("janus.plugin.sfu", this.loops ? parseInt(occupantId.replace("-l", "")) % this.loops : undefined);
 
     this.associate(conn, handle);
 


### PR DESCRIPTION
Don't subscribe to audio/video if occupantId ends with '-l' meaning they are only listener and doesn't talk.
The avatar position and chat are still working because datachannel is send/receive on the publisher RTCPeerConnection connection.

Less sessions (RTCPeerConnection) are created on the server, so normally less cpu.
That's a hacky and simple way of doing some of the use case I talked about in https://github.com/networked-aframe/janus-plugin-sfu/pull/6
We still use a RTCPeerConnection for the listeners, if we could just use websocket and no RTCPeerConnection at all that would be even better, that would need changes in the rust code for sure, but I don't think that's possible to use janus websocket without having a session.

cc @arpu